### PR TITLE
Tests check against MariaDB COLUMN_CHECK and COLUMN_CREATE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 # Config file for automatic testing at travis-ci.org
-
-language: python
+sudo: required
 
 notifications:
   email: false
 
 language: python
 
+before_script: .travis/before_script.sh
+
 install:
   - pip install tox
 
-script: tox
+script: HYPOTHESIS_MAX_EXAMPLES=1000 tox

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+# Install MariaDB to replace the existing MySQL
+sudo service mysql stop
+sudo apt-get install -y python-software-properties
+sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db
+sudo add-apt-repository "deb http://ftp.osuosl.org/pub/mariadb/repo/10.0/ubuntu precise main"
+sudo apt-get update -qq
+yes Y | sudo apt-get install -y mariadb-server libmariadbclient-dev

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,18 @@
 History
 -------
 
+1.1.0
+-----
+
+* Tests now verify every operation against MariaDB's ``COLUMN_CHECK`` and
+  ``COLUMN_CREATE`` functions
+* Fixed column order when >1 UTF8 byte characters are involved
+* Fix encoding ``int``\s around size boundaries
+* Fix encoding ``time``\s and ``datetime``\s with microseconds=0
+* Fix encoding float ``-0.0``
+* Fix a data size boundaries off-by-one error
+* Fix decoding ``utf8mb4`` strings
+
 1.0.0
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -91,8 +91,8 @@ data direct from MariaDB and decoding in Python as opposed to with MariaDB's
 
 As noted above, ``DECIMAL`` values are not supported, and unpacking this
 will raise ``DynColNotSupported``. Also strings will only be decoded with the
-MySQL charset ``utf8mb4`` which corresponds to the full UTF-8 spec, and such
-strings will raise ``DynColNotSupported`` as well.
+MySQL charsets ``utf8`` or ``utf8mb4``; strings with other charsets will raise
+``DynColNotSupported`` as well.
 
 Unsupported column formats, for example the old MariaDB numbered dynamic
 columns format, or corrupt data, will raise ``DynColValueError``.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 hypothesis==1.11.4
+mysqlclient==1.3.6
 py==1.4.30
 pytest==2.7.1
 pytz==2015.6

--- a/tests/base.py
+++ b/tests/base.py
@@ -2,7 +2,9 @@
 from __future__ import unicode_literals
 
 import codecs
+from datetime import date, datetime, time
 
+import MySQLdb
 import six
 
 from mariadb_dyncol import pack, unpack
@@ -29,8 +31,89 @@ def check(dicty, hexstring, expected=None, hexstring_cut=False):
         hexed = hexed[:len(hexstring)]
     assert hexed == hexstring
 
+    # Verify against MariaDB
+    check_against_db(dicty, byte_string)
+
     unpacked = unpack(byte_string)
     # Nones are not stored and thus we shouldn't compare them
     if expected is None:
         expected = {k: v for k, v in dicty.items() if v is not None}
     assert unpacked == expected
+
+
+connection = None
+
+
+def get_connection():
+    global connection
+    if connection is None:
+        connection = MySQLdb.connect(
+            host='localhost',
+            charset='utf8',
+        )
+        cursor = connection.cursor()
+        try:
+            cursor.execute("SET GLOBAL max_allowed_packet = 1048576000")
+            cursor.execute("SELECT VERSION()")
+            version = cursor.fetchone()[0]
+        finally:
+            cursor.close()
+        assert 'MariaDB' in version
+    return connection
+
+
+def check_against_db(dicty, byte_string):
+    connection = get_connection()
+    cursor = connection.cursor()
+    try:
+        # Basic validity check
+        cursor.execute("SELECT COLUMN_CHECK(%s) AS r", (byte_string,))
+        result = cursor.fetchone()[0]
+        assert result == 1, (
+            "MariaDB did not validate %s" % hexs(byte_string)
+        )
+        # In depth check of re-creating with COLUMN_CREATE
+        sql, params = column_create(dicty)
+        sql = 'SELECT ' + sql + ' AS v'
+        cursor.execute(sql, params)
+        result = cursor.fetchone()[0]
+        assert hexs(byte_string) == hexs(result)
+    finally:
+        cursor.close()
+
+
+def column_create(dicty):
+    # COLUMN_CREATE() with no args is invalid so hardcode empty dict
+    if not dicty:
+        return "COLUMN_DELETE(COLUMN_CREATE('a', 1), 'a')", []
+
+    sql = []
+    params = []
+    for key, value in six.iteritems(dicty):
+        sql.append('%s')
+        params.append(key)
+        if isinstance(value, dict):
+            subsql, subparams = column_create(value)
+            sql.append(subsql)
+            params.extend(subparams)
+        elif value is None:
+            sql.append('NULL')
+        elif isinstance(value, six.integer_types + six.string_types):
+            sql.append('%s')
+            params.append(value)
+        elif isinstance(value, float):
+            # str(float) broken on Python 2, breaks the query
+            sql.append(repr(value) + ' AS DOUBLE')
+        else:
+            sql.append('%s AS ' + type_map[type(value)])
+            params.append(value)
+
+    sql = 'COLUMN_CREATE(' + ', '.join(sql) + ')'
+    return sql, params
+
+
+type_map = {
+    date: 'DATE',
+    datetime: 'DATETIME',
+    time: 'TIME',
+}

--- a/tests/test_mariadb_dyncol.py
+++ b/tests/test_mariadb_dyncol.py
@@ -46,6 +46,10 @@ def test_a_1048576():
     check({"a": 1048576}, b"04010001000000000061000020")
 
 
+def test_0_2147483648():
+    check({'0': 2147483648}, b'040100010000000000300000000001')
+
+
 def test_ulonglongmax():
     check(
         {"a": 18446744073709551615},
@@ -102,9 +106,44 @@ def test_unicode_poo_1():
     check({"💩": 1}, b"040100040000000000F09F92A902")
 
 
-def test_large_string_data():
+def test_unicode_utf8mb4_unpack():
+    # All tests are using utf8 on connection but we should recognize utf8mb4
+    # as well
+    assert unpack(unhexs('040100010000000300612D61')) == {"a": "a"}
+
+
+def test_non_unicode_charset_fails():
+    with pytest.raises(DynColNotSupported):
+        unpack(unhexs('040100010000000300610861'))  # {'a': 'a'} in latin1
+
+
+def test_large_string_data_4093_as():
     check(
-        {'a': 'a' * (2 ** 12)},
+        {'a': 'a' * 4093},
+        b'0401000100000003006121616161',
+        hexstring_cut=True
+    )
+
+
+def test_large_string_data_4094_as():
+    check(
+        {'a': 'a' * 4094},
+        b'050100010000000300006121616161',
+        hexstring_cut=True
+    )
+
+
+def test_large_string_data_4095_as():
+    check(
+        {'a': 'a' * 4095},
+        b'050100010000000300006121616161',
+        hexstring_cut=True
+    )
+
+
+def test_large_string_data_4096_as():
+    check(
+        {'a': 'a' * 4096},
         b'050100010000000300006121616161',
         hexstring_cut=True
     )
@@ -145,10 +184,22 @@ def test_float_minus_3_415():
     check({"a": -3.415}, b"0401000100000002006152B81E85EB510BC0")
 
 
+def test_float_minus_0_0():
+    # MariaDB is discards the minus sign
+    check({"0": -0.0}, b"040100010000000200300000000000000000")
+
+
 def test_float_192873409809():
     check(
         {"a": 192873409809.0},
         b"040100010000000200610080885613744642"
+    )
+
+
+def test_float_1000000000000001():
+    check(
+        {'0': 1000000000000001.0},
+        b'0401000100000002003008003426F56B0C43'
     )
 
 
@@ -202,6 +253,14 @@ def test_datetime_2():
     )
 
 
+def test_datetime_no_microseconds():
+    check(
+        {"0": datetime(year=2000, month=1, day=1,
+                       hour=0, minute=0, second=0)},
+        b"0401000100000005003021A00F000000"
+    )
+
+
 def test_date():
     check(
         {"a": date(year=2015, month=1, day=1)},
@@ -227,6 +286,13 @@ def test_time_2():
     check(
         {"a": time(hour=3, minute=59, second=59, microsecond=999999)},
         b"040100010000000700613F42BFEF0300"
+    )
+
+
+def test_time_no_microseconds():
+    check(
+        {"a": time(hour=1, minute=2, second=3)},
+        b"04010001000000070061831000"
     )
 
 
@@ -262,6 +328,13 @@ def test_255_chars():
     check(
         {'a' * 255: 1},
         b'040100FF0000000000' + b''.join([b'61'] * 255) + b'02'
+    )
+
+
+def test_000_negative_lowest():
+    check(
+        {'000': -2147483647, '0\x80': -2147483647},
+        b'0402000600000000000300400030303030C280FDFFFFFFFDFFFFFF'
     )
 
 
@@ -324,6 +397,13 @@ def test_nested():
         {'falafel': {'a': 1}, 'fala': {'b': 't'}},
         b'0402000B00000008000400C80066616C6166616C6166656C040100010000000'
         b'3006221740401000100000000006102'
+    )
+
+
+def test_nested_empty():
+    check(
+        {'0': {}},
+        b'040100010000000800300400000000'
     )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ skipsdist = True
 [testenv]
 setenv =
     PYTHONDONTWRITEBYTECODE=1
+passenv = HYPOTHESIS_MAX_EXAMPLES
 install_command = pip install --no-deps {opts} {packages}
 deps = -rrequirements.txt
 commands = py.test {posargs}


### PR DESCRIPTION
This allowed the discovery of many bugs, which have been fixed:

* Fixed column order when >1 UTF8 byte characters are involved
* Fix encoding ``int``\s around size boundaries
* Fix encoding ``time``\s and ``datetime``\s with microseconds=0
* Fix encoding float ``-0.0``
* Fix a data size boundaries off-by-one error
* Fix decoding ``utf8mb4`` strings
