### PR TITLE
Add benchmark script and perform some optimization

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ History
 
 * pending
 * Disallowed ``str`` values on Python 2 - always use ``unicode``
+* Added a benchmark script and made some optimizations that add up to a speed
+  boost of about 10%.
 
 1.1.0 (2015-10-13)
 ------------------

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+from __future__ import division, print_function, unicode_literals
+
+import sys
+import time
+from contextlib import contextmanager
+
+import six
+from tests import base, test_mariadb_dyncol
+
+
+def main():
+    nruns = 1000
+    base.check_against_db = lambda *a, **kw: 0
+
+    test_funcs = get_test_funcs()
+    print("Running benchmark", file=sys.stderr)
+    start = time.time()
+    for i in range(nruns):
+        print(".", file=sys.stderr, end='')
+        sys.stderr.flush()
+        [test_func() for test_func in test_funcs]
+    total = time.time() - start
+    print('\n', file=sys.stderr)
+    print("Ran all tests {} times in {} seconds = {} seconds per run".format(
+        nruns,
+        total,
+        total / nruns
+    ), file=sys.stderr)
+
+
+def get_test_funcs():
+    funcs = []
+    for name in dir(test_mariadb_dyncol):
+        if not name.startswith('test_'):
+            continue
+
+        testfunc = getattr(test_mariadb_dyncol, name)
+        if hasattr(testfunc, 'slow'):
+            continue
+
+        if hasattr(testfunc, 'skipif') and testfunc.skipif.args[0] == True:
+            continue
+
+        funcs.append(testfunc)
+    return funcs
+
+
+@contextmanager
+def captured_output(stream_name):
+    """Return a context manager used by captured_stdout/stdin/stderr
+    that temporarily replaces the sys stream *stream_name* with a StringIO.
+
+    Note: This function and the following ``captured_std*`` are copied
+          from CPython's ``test.support`` module."""
+    orig_stdout = getattr(sys, stream_name)
+    setattr(sys, stream_name, six.StringIO())
+    try:
+        yield getattr(sys, stream_name)
+    finally:
+        setattr(sys, stream_name, orig_stdout)
+
+
+def captured_stdout():
+    """Capture the output of sys.stdout:
+
+       with captured_stdout() as stdout:
+           print("hello")
+       self.assertEqual(stdout.getvalue(), "hello\n")
+    """
+    return captured_output("stdout")
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_mariadb_dyncol.py
+++ b/tests/test_mariadb_dyncol.py
@@ -124,6 +124,7 @@ def test_str_not_accepted():
         pack({'a': str('value')})
 
 
+@pytest.mark.slow
 def test_large_string_data_4093_as():
     check(
         {'a': 'a' * 4093},
@@ -132,6 +133,7 @@ def test_large_string_data_4093_as():
     )
 
 
+@pytest.mark.slow
 def test_large_string_data_4094_as():
     check(
         {'a': 'a' * 4094},
@@ -140,6 +142,7 @@ def test_large_string_data_4094_as():
     )
 
 
+@pytest.mark.slow
 def test_large_string_data_4095_as():
     check(
         {'a': 'a' * 4095},
@@ -148,6 +151,7 @@ def test_large_string_data_4095_as():
     )
 
 
+@pytest.mark.slow
 def test_large_string_data_4096_as():
     check(
         {'a': 'a' * 4096},
@@ -156,6 +160,7 @@ def test_large_string_data_4096_as():
     )
 
 
+@pytest.mark.slow
 def test_large_string_data_2():
     check(
         {'a': 'a' * (2 ** 13), 'b': 1},
@@ -164,6 +169,7 @@ def test_large_string_data_2():
     )
 
 
+@pytest.mark.slow
 def test_huge_string_data():
     check(
         {'a': 'a' * (2 ** 20)},


### PR DESCRIPTION
Add a benchmark script that invokes the fast test cases over and over, and then use this along with `%timeit` profiling in IPython and `dis.dis` output to make some optimizations:

* Speed up integer encoding with only one call to `struct.pack`
* Speed up string encoding with no temporary variable
* Optimize `unpack` by using fewer temporary variables
* Use aliases for imports from `six` and `struct` to avoid repeat attribute access
* Speed up float encoding by making the `-0.0` check much faster
* Use dictionaries to look up the `encode_*` / `decode_*` functions

Overall the speed boost seems to be around 10%.