### PR TITLE
Fix for Python 2: disallow str values, unicode only

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ History
 ---------------
 
 * pending
+* Disallowed ``str`` values on Python 2 - always use ``unicode``
 
 1.1.0 (2015-10-13)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -82,8 +82,9 @@ of a normal query.
 The ``dict``\'s keys must all be unicode strings, and the values must all be
 one of the supported data types:
 
-* ``int`` between ``-(2 ** 32) + 1`` and ``(2 ** 64) - 1``
-* ``str`` up to 4GB
+* ``int`` between ``-(2 ** 32) + 1`` and ``(2 ** 64) - 1`` (Python 2: ``long``
+  is supported too)
+* ``str`` up to 4GB encoded in UTF-8 (Python 2: ``unicode``)
 * ``float`` - anything except ``NaN`` or ``+/- inf``
 * ``datetime.datetime`` - full range supported
 * ``datetime.date`` - full range supported

--- a/mariadb_dyncol/base.py
+++ b/mariadb_dyncol/base.py
@@ -80,7 +80,7 @@ def pack(dicty):
             dtype, encvalue = encode_int(value)
         elif isinstance(value, float):
             dtype, encvalue = encode_float(value)
-        elif isinstance(value, six.string_types):
+        elif isinstance(value, six.text_type):
             dtype, encvalue = encode_string(value)
         elif isinstance(value, datetime):
             dtype, encvalue = encode_datetime(value)

--- a/tests/test_mariadb_dyncol.py
+++ b/tests/test_mariadb_dyncol.py
@@ -5,6 +5,7 @@ from datetime import date, datetime, time
 from decimal import Decimal
 
 import pytest
+import six
 
 from mariadb_dyncol import (
     DynColLimitError, DynColNotSupported, DynColTypeError, DynColValueError,
@@ -115,6 +116,12 @@ def test_unicode_utf8mb4_unpack():
 def test_non_unicode_charset_fails():
     with pytest.raises(DynColNotSupported):
         unpack(unhexs('040100010000000300610861'))  # {'a': 'a'} in latin1
+
+
+@pytest.mark.skipif(not six.PY2, reason="requires Python 2")
+def test_str_not_accepted():
+    with pytest.raises(DynColTypeError):
+        pack({'a': str('value')})
 
 
 def test_large_string_data_4093_as():


### PR DESCRIPTION
As noticed during development of Django DynamicField in adamchainz/django-mysql#83