### PR TITLE
Travis test on container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 # Config file for automatic testing at travis-ci.org
-sudo: required
+sudo: false
 
 notifications:
   email: false
 
 language: python
 python: 3.5
-
-before_script: .travis/before_script.sh
+addons:
+    mariadb: 10.0
 
 install:
   - pip install tox

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -e
-
-# Install MariaDB to replace the existing MySQL
-sudo service mysql stop
-sudo apt-get install -y python-software-properties
-sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db
-sudo add-apt-repository "deb http://ftp.osuosl.org/pub/mariadb/repo/10.0/ubuntu precise main"
-sudo apt-get update -qq
-yes Y | sudo apt-get install -y mariadb-server libmariadbclient-dev


### PR DESCRIPTION
MariaDB is now available as an addon, so we should be able to use containers for faster tests.