### PR TITLE
Improve tests

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -13,22 +13,27 @@ hexs = binascii.hexlify
 unhexs = binascii.unhexlify
 
 
-def check(input, hexstring, expected=None, hexstring_cut=False):
-    byte_string = pack(input)
-    assert isinstance(byte_string, six.binary_type)
-    hexed = hexs(byte_string)
-    if hexstring_cut:
-        hexed = hexed[:len(hexstring)]
-    assert hexed == hexstring
+def check(input, expected=None, expected_prefix=None):
+    if expected is not None:
+        assert expected_prefix is None
 
-    # Verify against MariaDB
-    check_against_db(input, byte_string)
+    packed = pack(input)
+    assert isinstance(packed, six.binary_type)
 
-    unpacked = unpack(byte_string)
+    packed_hex = hexs(packed)
+    if expected is not None:
+        assert packed_hex == expected
+    elif expected_prefix is not None:
+        packed_hex_prefix = packed_hex[:len(expected_prefix)]
+        assert packed_hex_prefix == expected_prefix
+
+    check_against_db(input, packed)
+
+    unpacked = unpack(packed)
+
     # Nones are not stored and thus we shouldn't compare them
-    if expected is None:
-        expected = {k: v for k, v in input.items() if v is not None}
-    assert unpacked == expected
+    expected_unpacked = {k: v for k, v in input.items() if v is not None}
+    assert unpacked == expected_unpacked
 
 
 connection = None

--- a/tests/test_mariadb_dyncol.py
+++ b/tests/test_mariadb_dyncol.py
@@ -14,100 +14,154 @@ from .base import check, hexs, unhexs
 
 
 def test_empty():
-    check({}, b"0400000000")
+    check(
+        input={},
+        expected=b"0400000000",
+    )
 
 
 def test_a_1():
-    check({"a": 1}, b"0401000100000000006102")
+    check(
+        input={"a": 1},
+        expected=b"0401000100000000006102",
+    )
 
 
 def test_a_minus1():
-    check({"a": -1}, b"0401000100000000006101")
+    check(
+        input={"a": -1},
+        expected=b"0401000100000000006101",
+    )
 
 
 def test_a_minus2():
-    check({"a": -2}, b"0401000100000000006103")
+    check(
+        input={"a": -2},
+        expected=b"0401000100000000006103",
+    )
 
 
 def test_a_0():
-    check({"a": 0}, b"04010001000000000061")
+    check(
+        input={"a": 0},
+        expected=b"04010001000000000061",
+    )
 
 
 def test_a_128():
-    check({"a": 128}, b"040100010000000000610001")
+    check(
+        input={"a": 128},
+        expected=b"040100010000000000610001",
+    )
 
 
 def test_a_65535():
-    check({"a": 65535}, b"04010001000000000061feff01")
+    check(
+        input={"a": 65535},
+        expected=b"04010001000000000061feff01",
+    )
 
 
 def test_a_1048576():
-    check({"a": 1048576}, b"04010001000000000061000020")
+    check(
+        input={"a": 1048576},
+        expected=b"04010001000000000061000020",
+    )
 
 
 def test_0_2147483648():
-    check({'0': 2147483648}, b'040100010000000000300000000001')
+    check(
+        input={'0': 2147483648},
+        expected=b'040100010000000000300000000001',
+    )
 
 
 def test_ulonglongmax():
     check(
-        {"a": 18446744073709551615},
-        b"04010001000000010061ffffffffffffffff"
+        input={"a": 18446744073709551615},
+        expected=b"04010001000000010061ffffffffffffffff",
     )
 
 
 def test_integer_overflow():
     with pytest.raises(DynColValueError):
-        check({"a": 2 ** 64}, b"unchecked")
+        pack({"a": 2 ** 64})
 
 
 def test_integer_negative_overflow():
     with pytest.raises(DynColValueError):
-        check({"a": -(2 ** 32)}, b"unchecked")
+        pack({"a": -(2 ** 32)})
 
 
 def test_c_1():
-    check({"c": 1}, b"0401000100000000006302")
+    check(
+        input={"c": 1},
+        expected=b"0401000100000000006302",
+    )
 
 
 def test_a_1_b_2():
-    check({"a": 1, "b": 2}, b"0402000200000000000100100061620204")
+    check(
+        input={"a": 1, "b": 2},
+        expected=b"0402000200000000000100100061620204",
+    )
 
 
 def test_a_1_b_2_c_3():
     check(
-        {"a": 1, "b": 2, "c": 3},
-        b"0403000300000000000100100002002000616263020406"
+        input={"a": 1, "b": 2, "c": 3},
+        expected=b"0403000300000000000100100002002000616263020406",
     )
 
 
 def test_abc_123():
-    check({"abc": 123}, b"040100030000000000616263f6")
+    check(
+        input={"abc": 123},
+        expected=b"040100030000000000616263f6",
+    )
 
 
 def test_string_empty():
-    check({"a": ""}, b"040100010000000300612d")
+    check(
+        input={"a": ""},
+        expected=b"040100010000000300612d",
+    )
 
 
 def test_empty_key():
-    check({"": ""}, b"0401000000000003002d")
+    check(
+        input={"": ""},
+        expected=b"0401000000000003002d",
+    )
 
 
 def test_string_values():
-    check({"a": "string"}, b"040100010000000300612d737472696e67")
+    check(
+        input={"a": "string"},
+        expected=b"040100010000000300612d737472696e67",
+    )
 
 
 def test_a_unicode_poo():
-    check({"a": "💩"}, b"040100010000000300612df09f92a9")
+    check(
+        input={"a": "💩"},
+        expected=b"040100010000000300612df09f92a9",
+    )
 
 
 def test_unicode_poo_1():
-    check({"💩": 1}, b"040100040000000000f09f92a902")
+    check(
+        input={"💩": 1},
+        expected=b"040100040000000000f09f92a902",
+    )
+
+
+def test_unicode_utf8mb3_unpack():
+    # aka just 'utf8'
+    assert unpack(unhexs('040100010000000300612161')) == {"a": "a"}
 
 
 def test_unicode_utf8mb4_unpack():
-    # All tests are using utf8 on connection but we should recognize utf8mb4
-    # as well
     assert unpack(unhexs('040100010000000300612d61')) == {"a": "a"}
 
 
@@ -125,92 +179,98 @@ def test_str_not_accepted():
 @pytest.mark.slow
 def test_large_string_data_4093_as():
     check(
-        {'a': 'a' * 4093},
-        b'040100010000000300612d616161',
-        hexstring_cut=True
+        input={'a': 'a' * 4093},
+        expected_prefix=b'040100010000000300612d616161',
     )
 
 
 @pytest.mark.slow
 def test_large_string_data_4094_as():
     check(
-        {'a': 'a' * 4094},
-        b'05010001000000030000612d616161',
-        hexstring_cut=True
+        input={'a': 'a' * 4094},
+        expected_prefix=b'05010001000000030000612d616161',
     )
 
 
 @pytest.mark.slow
 def test_large_string_data_4095_as():
     check(
-        {'a': 'a' * 4095},
-        b'05010001000000030000612d616161',
-        hexstring_cut=True
+        input={'a': 'a' * 4095},
+        expected_prefix=b'05010001000000030000612d616161',
     )
 
 
 @pytest.mark.slow
 def test_large_string_data_4096_as():
     check(
-        {'a': 'a' * 4096},
-        b'05010001000000030000612d616161',
-        hexstring_cut=True
+        input={'a': 'a' * 4096},
+        expected_prefix=b'05010001000000030000612d616161',
     )
 
 
 @pytest.mark.slow
 def test_large_string_data_2():
     check(
-        {'a': 'a' * (2 ** 13), 'b': 1},
-        b'05020002000000030000010010000261622d6161',
-        hexstring_cut=True
+        input={'a': 'a' * (2 ** 13), 'b': 1},
+        expected_prefix=b'05020002000000030000010010000261622d6161',
     )
 
 
 @pytest.mark.slow
 def test_huge_string_data():
     check(
-        {'a': 'a' * (2 ** 20)},
-        b'0601000100000003000000612d616161',
-        hexstring_cut=True
+        input={'a': 'a' * (2 ** 20)},
+        expected_prefix=b'0601000100000003000000612d616161',
     )
 
 
 def test_None():
-    check({"a": None}, b"0400000000")
+    check(
+        input={"a": None},
+        expected=b"0400000000",
+    )
 
 
 def test_dict():
     check(
-        {"a": {"b": "c"}},
-        b"04010001000000080061040100010000000300622d63"
+        input={"a": {"b": "c"}},
+        expected=b"04010001000000080061040100010000000300622d63",
     )
 
 
 def test_float_1_0():
-    check({"a": 1.0}, b"04010001000000020061000000000000f03f")
+    check(
+        input={"a": 1.0},
+        expected=b"04010001000000020061000000000000f03f",
+    )
 
 
 def test_float_minus_3_415():
-    check({"a": -3.415}, b"0401000100000002006152b81e85eb510bc0")
+    check(
+        input={"a": -3.415},
+        expected=b"0401000100000002006152b81e85eb510bc0",
+    )
 
 
 def test_float_minus_0_0():
-    # MariaDB is discards the minus sign
-    check({"0": -0.0}, b"040100010000000200300000000000000000")
+    # MariaDB discards the minus sign
+    check(
+        input={"0": -0.0},
+        expected=b"040100010000000200300000000000000000",
+    )
 
 
 def test_float_192873409809():
     check(
-        {"a": 192873409809.0},
-        b"040100010000000200610080885613744642"
+        input={"a": 192873409809.0},
+        expected=b"040100010000000200610080885613744642"
     )
 
 
 def test_float_1000000000000001():
     check(
-        {'0': 1000000000000001.0},
-        b'0401000100000002003008003426f56b0c43'
+        input={'0': 1000000000000001.0},
+        expected=b'0401000100000002003008003426f56b0c43',
     )
 
 
@@ -236,116 +296,113 @@ def test_unpack_Decimal_not_implemented():
 
 
 # def test_decimal_1():
-#     check({'a': Decimal('1')}, b'04010001000000040061090080000001')
+#     check(input={'a': Decimal('1')}, expected=b'04010001000000040061090080000001')
 
 
 # def test_decimal_123456789():
-#     check({'a': Decimal('123456789')}, b'040100010000000400610900875bcd15')
+#     check(input={'a': Decimal('123456789')}, expected=b'040100010000000400610900875bcd15')
 
 
 # def test_decimal_123456789_5():
-#     check({'a': Decimal('123456789.5')},
-#            b'040100010000000400610901875bcd1505')
+#     check(input={'a': Decimal('123456789.5')},
+#           expected=b'040100010000000400610901875bcd1505')
 
 
 def test_datetime():
     check(
-        {"a": datetime(year=1989, month=10, day=4,
-                       hour=3, minute=4, second=55, microsecond=142859)},
-        b"04010001000000050061448b0f0b2e72130300"
+        input={"a": datetime(year=1989, month=10, day=4, hour=3, minute=4, second=55, microsecond=142859)},
+        expected=b"04010001000000050061448b0f0b2e72130300",
     )
 
 
 def test_datetime_2():
     check(
-        {"a": datetime(year=2300, month=12, day=25,
-                       hour=15, minute=55, second=12, microsecond=998134)},
-        b"0401000100000005006199f911f63acfdc0f00"
+        input={"a": datetime(year=2300, month=12, day=25, hour=15, minute=55, second=12, microsecond=998134)},
+        expected=b"0401000100000005006199f911f63acfdc0f00"
     )
 
 
 def test_datetime_no_microseconds():
     check(
-        {"0": datetime(year=2000, month=1, day=1,
-                       hour=0, minute=0, second=0)},
-        b"0401000100000005003021a00f000000"
+        input={"0": datetime(year=2000, month=1, day=1, hour=0, minute=0, second=0)},
+        expected=b"0401000100000005003021a00f000000",
     )
 
 
 def test_date():
     check(
-        {"a": date(year=2015, month=1, day=1)},
-        b"0401000100000006006121be0f"
+        input={"a": date(year=2015, month=1, day=1)},
+        expected=b"0401000100000006006121be0f",
     )
 
 
 def test_date_2():
     check(
-        {"a": date(year=1, month=12, day=25)},
-        b"04010001000000060061990300"
+        input={"a": date(year=1, month=12, day=25)},
+        expected=b"04010001000000060061990300",
     )
 
 
 def test_time():
     check(
-        {"a": time(hour=12, minute=2, second=3, microsecond=676767)},
-        b"040100010000000700619f533a080c00"
+        input={"a": time(hour=12, minute=2, second=3, microsecond=676767)},
+        expected=b"040100010000000700619f533a080c00",
     )
 
 
 def test_time_2():
     check(
-        {"a": time(hour=3, minute=59, second=59, microsecond=999999)},
-        b"040100010000000700613f42bfef0300"
+        input={"a": time(hour=3, minute=59, second=59, microsecond=999999)},
+        expected=b"040100010000000700613f42bfef0300",
     )
 
 
 def test_time_no_microseconds():
     check(
-        {"a": time(hour=1, minute=2, second=3)},
-        b"04010001000000070061831000"
+        input={"a": time(hour=1, minute=2, second=3)},
+        expected=b"04010001000000070061831000",
     )
 
 
 def test_cyrillic_key():
     check(
-        {'адын': 1212},
-        b'040100080000000000d0b0d0b4d18bd0bd7809'
+        input={'адын': 1212},
+        expected=b'040100080000000000d0b0d0b4d18bd0bd7809',
     )
 
 
 def test_1212_1212():
     check(
-        {"1212": 1212},
-        b'040100040000000000313231327809'
+        input={"1212": 1212},
+        expected=b'040100040000000000313231327809',
     )
 
 
 def test_two_keys():
     check(
-        {"1212": 2, "www": 3},
-        b'04020007000000000003001000777777313231320604',
+        input={"1212": 2, "www": 3},
+        expected=b'04020007000000000003001000777777313231320604',
     )
 
 
 def test_two_keys_other():
     check(
-        {"1": "AAA", "b": "BBB"},
-        b'0402000200000003000100430031622d4141412d424242',
+        input={"1": "AAA", "b": "BBB"},
+        expected=b'0402000200000003000100430031622d4141412d424242',
     )
 
 
 def test_255_chars():
     check(
-        {'a' * 255: 1},
-        b'040100ff0000000000' + b''.join([b'61'] * 255) + b'02'
+        input={'a' * 255: 1},
+        expected=b'040100ff0000000000' + b''.join([b'61'] * 255) + b'02'
     )
 
 
 def test_000_negative_lowest():
     check(
-        {'000': -2147483647, '0\x80': -2147483647},
-        b'0402000600000000000300400030303030c280fdfffffffdffffff'
+        input={'000': -2147483647, '0\x80': -2147483647},
+        expected=b'0402000600000000000300400030303030c280fdfffffffdffffff'
     )
 
 
@@ -353,8 +410,8 @@ def test_MAX_NAME_LENGTH_chars():
     long_key = 'a' * MAX_NAME_LENGTH
     long_key_encoded = long_key.encode('utf-8')
     check(
-        {long_key: 1},
-        b'040100ff3f00000000' + hexs(long_key_encoded) + b'02'
+        input={long_key: 1},
+        expected=b'040100ff3f00000000' + hexs(long_key_encoded) + b'02'
     )
 
 
@@ -367,8 +424,8 @@ def test_name_unicode_fits():
     long_key = ('💩' * 4095) + ('a' * 3)  # MAX_NAME_LENGTH bytes
     long_key_encoded = long_key.encode('utf8')
     check(
-        {long_key: 1},
-        b'040100ff3f00000000' + hexs(long_key_encoded) + b'02'
+        input={long_key: 1},
+        expected=b'040100ff3f00000000' + hexs(long_key_encoded) + b'02'
     )
 
 
@@ -380,8 +437,7 @@ def test_name_unicode_overflow():
 
 def test_total_name_length():
     long_key = 'a' * (MAX_NAME_LENGTH - 1)
-    # No exception
-    pack({
+    check({
         long_key + '1': 1,
         long_key + '2': 1,
         long_key + '3': 1,
@@ -405,15 +461,15 @@ def test_total_name_length_overflow():
 
 def test_nested():
     check(
-        {'falafel': {'a': 1}, 'fala': {'b': 't'}},
-        b'0402000b00000008000400c80066616c6166616c6166656c040100010000000300622d740401000100000000006102'
+        input={'falafel': {'a': 1}, 'fala': {'b': 't'}},
+        expected=b'0402000b00000008000400c80066616c6166616c6166656c040100010000000300622d740401000100000000006102',
     )
 
 
 def test_nested_empty():
     check(
-        {'0': {}},
-        b'040100010000000800300400000000'
+        input={'0': {}},
+        expected=b'040100010000000800300400000000',
     )
 
 


### PR DESCRIPTION
Use keyword arguments with better names to `check()`

Also add a test for a 'utf8mb3' encoded string in follow-up to #149.