### PR TITLE
Use Hypothesis native date/datetime/time strategies

### DIFF
--- a/tests/fuzztests.py
+++ b/tests/fuzztests.py
@@ -1,9 +1,7 @@
-from copy import deepcopy
 from math import isinf, isnan
 
 from hypothesis import assume, given
-from hypothesis.extra.datetime import datetimes
-from hypothesis.strategies import dictionaries, floats, integers, recursive, text
+from hypothesis.strategies import dates, datetimes, dictionaries, floats, integers, recursive, text, times
 
 from mariadb_dyncol import DynColValueError, pack, unpack
 from mariadb_dyncol.base import MAX_NAME_LENGTH, MAX_TOTAL_NAME_LENGTH  # priv.
@@ -26,9 +24,9 @@ valid_ints = integers(
 valid_floats = floats().filter(
     lambda f: not isnan(f) and not isinf(f)
 )
-valid_datetimes = datetimes(timezones=[])
-valid_dates = deepcopy(valid_datetimes).map(lambda dt: dt.date())
-valid_times = deepcopy(valid_datetimes).map(lambda dt: dt.time())
+valid_datetimes = datetimes()
+valid_dates = dates()
+valid_times = times()
 
 
 def valid_dictionaries(keys, values):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{27,36}-{unit,fuzz},
-    py{27,36}-codestyle
+    py{27,3}-{unit,fuzz},
+    py{27,3}-codestyle
 
 [testenv]
 setenv =
@@ -14,7 +14,7 @@ commands = pytest {posargs}
 [testenv:py27-fuzz]
 commands = pytest {posargs} tests/fuzztests.py
 
-[testenv:py34-fuzz]
+[testenv:py3-fuzz]
 commands = pytest {posargs} tests/fuzztests.py
 
 [testenv:py27-codestyle]
@@ -22,6 +22,6 @@ commands = pytest {posargs} tests/fuzztests.py
 skip_install = true
 commands = multilint --skip setup.py
 
-[testenv:py36-codestyle]
+[testenv:py3-codestyle]
 skip_install = true
 commands = multilint


### PR DESCRIPTION
Fix these warnings showing in tests from newer hypothesis versions, as the datetime strategy was moved from 'extra' to a built-in, and standalone date and time strategies were added.

Also making tox file run with whatever version of Python 3 is present, fixing running Python 3 fuzz tests on Travis.