### PR TITLE
Remove Python 2 support

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ Pending release
 
 .. Insert new release notes below this line
 
+* Drop Python 2 support, only Python 3.4+ is supported now.
+
 2.0.0 (2018-10-20)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -19,11 +19,21 @@ A quick example:
     >>> mariadb_dyncol.unpack(mariadb_dyncol.pack({"key": "value"}))
     {'key': 'value'}
 
+Installation
+============
+
+Use **pip**:
+
+.. code-block:: sh
+
+    pip install mariadb-dyncol
+
+Tested on Python 3.6. Python 3.4+ supported.
+
 Features
 ========
 
 * Sensible type mapping from Python to SQL
-* Tested on Python 2.7 and 3.6
 * Tested against examples from MariaDB, including property/fuzz testing with
   `hypothesis <https://hypothesis.readthedocs.io/en/latest/>`_ (which is
   amazing and found many bugs)

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,12 +1,8 @@
 #!/usr/bin/env python
-# -*- coding:utf-8 -*-
-from __future__ import division, print_function, unicode_literals
-
+import io
 import sys
 import time
 from contextlib import contextmanager
-
-import six
 
 from tests import base, test_mariadb_dyncol
 
@@ -56,7 +52,7 @@ def captured_output(stream_name):
     Note: This function and the following ``captured_std*`` are copied
           from CPython's ``test.support`` module."""
     orig_stdout = getattr(sys, stream_name)
-    setattr(sys, stream_name, six.StringIO())
+    setattr(sys, stream_name, io.StringIO())
     try:
         yield getattr(sys, stream_name)
     finally:

--- a/mariadb_dyncol/__init__.py
+++ b/mariadb_dyncol/__init__.py
@@ -1,6 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import unicode_literals
-
 from .base import DynColLimitError, DynColNotSupported, DynColTypeError, DynColValueError, pack, unpack
 
 __author__ = 'Adam Johnson'

--- a/mariadb_dyncol/base.py
+++ b/mariadb_dyncol/base.py
@@ -1,18 +1,9 @@
-# -*- coding:utf-8 -*-
-from __future__ import unicode_literals
-
 from datetime import date, datetime, time
 from decimal import Decimal
 from math import isinf, isnan
 from struct import pack as struct_pack
 from struct import unpack as struct_unpack
 from struct import unpack_from as struct_unpack_from
-
-from six import PY2
-from six import iteritems as six_iteritems
-from six import iterkeys as six_iterkeys
-from six import text_type
-from six.moves import range as six_moves_range
 
 DYN_COL_INT = 0
 DYN_COL_UINT = 1
@@ -67,10 +58,10 @@ def pack(dicty):
 
     dicty_names_encoded = {
         key.encode('utf-8'): value
-        for key, value in six_iteritems(dicty)
+        for key, value in dicty.items()
     }
 
-    for encname in sorted(six_iterkeys(dicty_names_encoded), key=name_order):
+    for encname in sorted(dicty_names_encoded.keys(), key=name_order):
         value = dicty_names_encoded[encname]
         if value is None:
             continue
@@ -254,14 +245,10 @@ ENCODE_FUNCS = {
     datetime: encode_datetime,
     time: encode_time,
     float: encode_float,
-    text_type: encode_string,
+    str: encode_string,
     Decimal: encode_decimal,
     dict: encode_dict,
 }
-
-if PY2:
-    from __builtin__ import long  # Avoid python 3 lint error
-    ENCODE_FUNCS[long] = encode_int
 
 
 def unpack(buf):
@@ -290,7 +277,7 @@ def unpack(buf):
     last_data_offset = None
     last_dtype = None
 
-    for i in six_moves_range(column_count):
+    for i in range(column_count):
         if coldata_size % 2 == 0:
             name_offset, data_offset_dtype = struct_unpack_from(
                 '<H' + data_offset_code,
@@ -333,7 +320,7 @@ def unpack(buf):
     # join data and names
     return {
         names[i]: values[i]
-        for i in six_moves_range(column_count)
+        for i in range(column_count)
     }
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,5 @@
 docutils
 flake8
-futures<3.2.0
 hypothesis
 isort
 multilint
@@ -8,4 +7,3 @@ PyMySQL
 pytest
 Pygments
 pytz
-six>=1.9.0,<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,18 +6,13 @@
 #
 atomicwrites==1.2.1       # via pytest
 attrs==18.2.0             # via hypothesis, pytest
-configparser==3.7.1       # via flake8
 docutils==0.14
-enum34==1.1.6             # via flake8, hypothesis
 flake8==3.6.0
-funcsigs==1.0.2           # via pytest
-futures==3.1.1
 hypothesis==4.4.3
 isort==4.3.4
 mccabe==0.6.1             # via flake8
 more-itertools==5.0.0     # via pytest
 multilint==2.4.0
-pathlib2==2.3.3           # via pytest
 pluggy==0.8.1             # via pytest
 py==1.7.0                 # via pytest
 pycodestyle==2.4.0        # via flake8
@@ -26,5 +21,4 @@ pygments==2.3.1
 pymysql==0.9.3
 pytest==4.1.1
 pytz==2018.9
-scandir==1.9.0            # via pathlib2
-six==1.12.0
+six==1.12.0               # via more-itertools, multilint, pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [flake8]
 max-line-length = 120
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-import codecs
 import os
 import re
 
@@ -7,17 +5,17 @@ from setuptools import find_packages, setup
 
 
 def get_version(filename):
-    with codecs.open(filename, 'r', 'utf-8') as fp:
+    with open(filename, 'r') as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
 
 version = get_version(os.path.join('mariadb_dyncol', '__init__.py'))
 
-with codecs.open('README.rst', 'r', 'utf-8') as readme_file:
+with open('README.rst', 'r') as readme_file:
     readme = readme_file.read()
 
-with codecs.open('HISTORY.rst', 'r', 'utf-8') as history_file:
+with open('HISTORY.rst', 'r') as history_file:
     history = history_file.read().replace('.. :changelog:', '')
 
 
@@ -32,10 +30,7 @@ setup(
     url='https://github.com/adamchainz/mariadb-dyncol',
     packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,
-    install_requires=[
-        'six>=1.9.0,<2.0',
-    ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=3.4',
     license="BSD",
     zip_safe=False,
     keywords='MariaDB',
@@ -45,8 +40,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,11 +1,7 @@
-# -*- coding:utf-8 -*-
-from __future__ import unicode_literals
-
 import binascii
 from datetime import date, datetime, time
 
 import pymysql
-import six
 
 from mariadb_dyncol import pack, unpack
 
@@ -18,7 +14,7 @@ def check(input, expected=None, expected_prefix=None):
         assert expected_prefix is None
 
     packed = pack(input)
-    assert isinstance(packed, six.binary_type)
+    assert isinstance(packed, bytes)
 
     packed_hex = hexs(packed)
     if expected is not None:
@@ -83,7 +79,7 @@ def column_create(dicty):
 
     sql = []
     params = []
-    for key, value in six.iteritems(dicty):
+    for key, value in dicty.items():
         sql.append('%s')
         params.append(key)
         if isinstance(value, dict):
@@ -92,11 +88,11 @@ def column_create(dicty):
             params.extend(subparams)
         elif value is None:
             sql.append('NULL')
-        elif isinstance(value, six.integer_types + six.string_types):
+        elif isinstance(value, (int, str)):
             sql.append('%s')
             params.append(value)
         elif isinstance(value, float):
-            # str(float) broken on Python 2, breaks the query
+            # str(float) breaks the query, instead use repr direct as SQL
             sql.append(repr(value) + ' AS DOUBLE')
         else:
             sql.append('%s AS ' + type_map[type(value)])

--- a/tests/test_mariadb_dyncol.py
+++ b/tests/test_mariadb_dyncol.py
@@ -1,11 +1,7 @@
-# -*- coding:utf-8 -*-
-from __future__ import unicode_literals
-
 from datetime import date, datetime, time
 from decimal import Decimal
 
 import pytest
-import six
 
 from mariadb_dyncol import DynColLimitError, DynColNotSupported, DynColTypeError, DynColValueError, pack, unpack
 from mariadb_dyncol.base import MAX_NAME_LENGTH  # private but useful in tests
@@ -168,12 +164,6 @@ def test_unicode_utf8mb4_unpack():
 def test_non_unicode_charset_fails():
     with pytest.raises(DynColNotSupported):
         unpack(unhexs('040100010000000300610861'))  # {'a': 'a'} in latin1
-
-
-@pytest.mark.skipif(not six.PY2, reason="requires Python 2")
-def test_str_not_accepted():
-    with pytest.raises(DynColTypeError):
-        pack({'a': str('value')})
 
 
 @pytest.mark.slow

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{27,3}-{unit,fuzz},
-    py{27,3}-codestyle
+    py3-{unit,fuzz},
+    py3-codestyle
 
 [testenv]
 setenv =
@@ -11,16 +11,8 @@ install_command = pip install --no-deps {opts} {packages}
 deps = -rrequirements.txt
 commands = pytest {posargs}
 
-[testenv:py27-fuzz]
-commands = pytest {posargs} tests/fuzztests.py
-
 [testenv:py3-fuzz]
 commands = pytest {posargs} tests/fuzztests.py
-
-[testenv:py27-codestyle]
-# setup.py check broken on travis python 2.7
-skip_install = true
-commands = multilint --skip setup.py
 
 [testenv:py3-codestyle]
 skip_install = true


### PR DESCRIPTION
* Remove coding header and `__future__` imports
* Remove use of `six`
* In `setup.py`, remove use of `codecs.open`, stop requiring 'six' in `install_requires`, update `python_requires`, and update `classifiers`
* In `README.rst`, update to "Python 3.4+ supported."
* In `requirements.in`,  remove `futures` pin and `six`, and recompile
* In `tox.ini`, stop testing on Python 2
* In `setup.cfg`, remove universal wheel building