### PR TITLE
Fix Pytest marker warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = --strict-markers
+markers = slow


### PR DESCRIPTION
Fix the below warning about the slow marker not being registered, and add the strict markers option as per the docs at https://docs.pytest.org/en/latest/mark.html.

```
.tox/py36/lib/python3.6/site-packages/_pytest/mark/structures.py:324
  /Users/chainz/Documents/Projects/mariadb-dyncol/.tox/py36/lib/python3.6/site-packages/_pytest/mark/structures.py:324: PytestUnknownMarkWarning: Unknown pytest.mark.slow - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,
````