### PR TITLE
Format code with Black

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,9 @@ mariadb-dyncol
 .. image:: https://img.shields.io/travis/adamchainz/mariadb-dyncol/master.svg
         :target: https://travis-ci.org/adamchainz/mariadb-dyncol
 
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+    :target: https://github.com/python/black
+
 Pack/unpack Python ``dict``\s into/out of MariaDB's **Dynamic Columns** format.
 
 A quick example:

--- a/benchmark.py
+++ b/benchmark.py
@@ -14,30 +14,31 @@ def main():
     test_funcs = get_test_funcs()
     print("Running benchmark", file=sys.stderr)
     start = time.time()
-    for i in range(nruns):
-        print(".", file=sys.stderr, end='')
+    for _ in range(nruns):
+        print(".", file=sys.stderr, end="")
         sys.stderr.flush()
         [test_func() for test_func in test_funcs]
     total = time.time() - start
-    print('\n', file=sys.stderr)
-    print("Ran all tests {} times in {} seconds = {} seconds per run".format(
-        nruns,
-        total,
-        total / nruns
-    ), file=sys.stderr)
+    print("\n", file=sys.stderr)
+    print(
+        "Ran all tests {} times in {} seconds = {} seconds per run".format(
+            nruns, total, total / nruns
+        ),
+        file=sys.stderr,
+    )
 
 
 def get_test_funcs():
     funcs = []
     for name in dir(test_mariadb_dyncol):
-        if not name.startswith('test_'):
+        if not name.startswith("test_"):
             continue
 
         testfunc = getattr(test_mariadb_dyncol, name)
-        if hasattr(testfunc, 'slow'):
+        if hasattr(testfunc, "slow"):
             continue
 
-        if hasattr(testfunc, 'skipif') and testfunc.skipif.args[0]:
+        if hasattr(testfunc, "skipif") and testfunc.skipif.args[0]:
             continue
 
         funcs.append(testfunc)
@@ -69,5 +70,5 @@ def captured_stdout():
     return captured_output("stdout")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/mariadb_dyncol/__init__.py
+++ b/mariadb_dyncol/__init__.py
@@ -1,7 +1,21 @@
-from .base import DynColLimitError, DynColNotSupported, DynColTypeError, DynColValueError, pack, unpack
+from .base import (
+    DynColLimitError,
+    DynColNotSupported,
+    DynColTypeError,
+    DynColValueError,
+    pack,
+    unpack,
+)
 
-__author__ = 'Adam Johnson'
-__email__ = 'me@adamj.eu'
-__version__ = '3.0.0'
+__author__ = "Adam Johnson"
+__email__ = "me@adamj.eu"
+__version__ = "3.0.0"
 
-__all__ = ('DynColLimitError', 'DynColNotSupported', 'DynColTypeError', 'DynColValueError', 'pack', 'unpack')
+__all__ = (
+    "DynColLimitError",
+    "DynColNotSupported",
+    "DynColTypeError",
+    "DynColValueError",
+    "pack",
+    "unpack",
+)

--- a/mariadb_dyncol/base.py
+++ b/mariadb_dyncol/base.py
@@ -16,7 +16,7 @@ DYN_COL_TIME = 7
 DYN_COL_DYNCOL = 8
 
 MAX_TOTAL_NAME_LENGTH = 65535
-MAX_NAME_LENGTH = (MAX_TOTAL_NAME_LENGTH // 4)
+MAX_NAME_LENGTH = MAX_TOTAL_NAME_LENGTH // 4
 
 
 class DynColLimitError(Exception):
@@ -56,10 +56,7 @@ def pack(dicty):
     data = []
     total_encname_length = 0
 
-    dicty_names_encoded = {
-        key.encode('utf-8'): value
-        for key, value in dicty.items()
-    }
+    dicty_names_encoded = {key.encode("utf-8"): value for key, value in dicty.items()}
 
     for encname in sorted(dicty_names_encoded.keys(), key=name_order):
         value = dicty_names_encoded[encname]
@@ -67,7 +64,7 @@ def pack(dicty):
             continue
 
         if len(encname) > MAX_NAME_LENGTH:
-            raise DynColLimitError("Key too long: " + encname.decode('utf-8'))
+            raise DynColLimitError("Key too long: " + encname.decode("utf-8"))
         total_encname_length += len(encname)
         if total_encname_length > MAX_TOTAL_NAME_LENGTH:
             raise DynColLimitError("Total length of keys too long")
@@ -90,24 +87,14 @@ def pack(dicty):
 
     data_size_flag, coldir_size_code, odd_sized_datacode = data_size(data)
 
-    flags = (
-        4 |  # means this contains named dynamic columns
-        data_size_flag
-    )
-    enc_names = b''.join(names)
+    flags = 4 | data_size_flag  # means this contains named dynamic columns
+    enc_names = b"".join(names)
 
-    buf = [
-        struct_pack(
-            '<BHH',
-            flags,
-            column_count,
-            len(enc_names)
-        ),
-    ]
+    buf = [struct_pack("<BHH", flags, column_count, len(enc_names))]
     if not odd_sized_datacode:
         buf.append(
             struct_pack(
-                '<' + ('H' + coldir_size_code) * (len(column_directory) // 2),
+                "<" + ("H" + coldir_size_code) * (len(column_directory) // 2),
                 *column_directory
             )
         )
@@ -115,14 +102,14 @@ def pack(dicty):
         for i, val in enumerate(column_directory):
             if i % 2 == 0:
                 # name_offset
-                buf.append(struct_pack('<H', val))
+                buf.append(struct_pack("<H", val))
             else:
                 # data_offset + dtype, have to cut last byte
-                val = struct_pack('<' + coldir_size_code, val)
+                val = struct_pack("<" + coldir_size_code, val)
                 buf.append(val[:-1])
     buf.append(enc_names)
     buf.extend(data)
-    return b''.join(buf)
+    return b"".join(buf)
 
 
 def name_order(name):
@@ -132,12 +119,12 @@ def name_order(name):
 
 def data_size(data):
     data_len = sum(len(d) for d in data)
-    if data_len < 0xfff:
-        return 0, 'H', False
-    elif data_len < 0xfffff:
-        return 1, 'L', True
-    elif data_len < 0xfffffff:
-        return 2, 'L', False
+    if data_len < 0xFFF:
+        return 0, "H", False
+    elif data_len < 0xFFFFF:
+        return 1, "L", True
+    elif data_len < 0xFFFFFFF:
+        return 2, "L", False
     else:
         raise ValueError("Too much data")
 
@@ -160,25 +147,25 @@ def encode_int(value):
 
     to_enc = []
     while encvalue:
-        to_enc.append(encvalue & 0xff)
+        to_enc.append(encvalue & 0xFF)
         encvalue = encvalue >> 8
-    return dtype, struct_pack('B' * len(to_enc), *to_enc)
+    return dtype, struct_pack("B" * len(to_enc), *to_enc)
 
 
 def encode_float(value):
     if isnan(value) or isinf(value):
         raise DynColValueError("Float value not encodeable: {}".format(value))
-    encvalue = struct_pack('d', value)
+    encvalue = struct_pack("d", value)
 
     # -0.0 is not supported in SQL, change to 0.0
-    if encvalue == b'\x00\x00\x00\x00\x00\x00\x00\x80':
-        encvalue = b'\x00\x00\x00\x00\x00\x00\x00\x00'
+    if encvalue == b"\x00\x00\x00\x00\x00\x00\x00\x80":
+        encvalue = b"\x00\x00\x00\x00\x00\x00\x00\x00"
 
     return DYN_COL_DOUBLE, encvalue
 
 
 def encode_string(value):
-    return DYN_COL_STRING, b'\x2D' + value.encode('utf-8')
+    return DYN_COL_STRING, b"\x2D" + value.encode("utf-8")
 
 
 def encode_decimal(value):
@@ -214,25 +201,21 @@ def encode_date(value):
     # We don't need any validation since datetime.date is more limited than the
     # MySQL format
     val = value.day | value.month << 5 | value.year << 9
-    return DYN_COL_DATE, struct_pack('I', val)[:-1]
+    return DYN_COL_DATE, struct_pack("I", val)[:-1]
 
 
 def encode_time(value):
     if value.microsecond > 0:
         val = (
-            value.microsecond |
-            value.second << 20 |
-            value.minute << 26 |
-            value.hour << 32
+            value.microsecond
+            | value.second << 20
+            | value.minute << 26
+            | value.hour << 32
         )
-        return DYN_COL_TIME, struct_pack('Q', val)[:6]
+        return DYN_COL_TIME, struct_pack("Q", val)[:6]
     else:
-        val = (
-            value.second |
-            value.minute << 6 |
-            value.hour << 12
-        )
-        return DYN_COL_TIME, struct_pack('I', val)[:3]
+        val = value.second | value.minute << 6 | value.hour << 12
+        return DYN_COL_TIME, struct_pack("I", val)[:3]
 
 
 def encode_dict(value):
@@ -255,7 +238,7 @@ def unpack(buf):
     """
     Convert MariaDB dynamic columns data in a byte string into a dict
     """
-    flags, column_count, len_names = struct_unpack_from('<BHH', buf)
+    flags, column_count, len_names = struct_unpack_from("<BHH", buf)
     data_offset_code, coldata_size, data_offset_mask = decode_data_size(flags)
     if (flags & 0xFC) != 4:
         raise DynColValueError("Unknown dynamic columns format")
@@ -266,7 +249,7 @@ def unpack(buf):
     column_directory_end = (1 + 2 + 2) + coldata_size * column_count
     names_end = column_directory_end + len_names
 
-    column_directory = buf[(1 + 2 + 2):column_directory_end]
+    column_directory = buf[1 + 2 + 2 : column_directory_end]
     enc_names = buf[column_directory_end:names_end]
     data = buf[names_end:]
 
@@ -280,21 +263,18 @@ def unpack(buf):
     for i in range(column_count):
         if coldata_size % 2 == 0:
             name_offset, data_offset_dtype = struct_unpack_from(
-                '<H' + data_offset_code,
-                column_directory,
-                offset=i * coldata_size
+                "<H" + data_offset_code, column_directory, offset=i * coldata_size
             )
         else:
             name_offset, = struct_unpack_from(
-                '<H',
-                column_directory,
-                offset=i * coldata_size
+                "<H", column_directory, offset=i * coldata_size
             )
             # can't struct_unpack the 3 bytes so hack around
-            dodt_bytes = column_directory[(i * coldata_size + 2):
-                                          (i * coldata_size + 5)] + b'\x00'
-            data_offset_dtype, = struct_unpack('<' + data_offset_code,
-                                               dodt_bytes)
+            dodt_bytes = (
+                column_directory[i * coldata_size + 2 : (i * coldata_size + 5)]
+                + b"\x00"
+            )
+            data_offset_dtype, = struct_unpack("<" + data_offset_code, dodt_bytes)
 
         data_offset_dtype &= data_offset_mask
         data_offset = data_offset_dtype >> 4
@@ -302,36 +282,30 @@ def unpack(buf):
 
         # Store *last* column's name
         if last_name_offset is not None:
-            names[i - 1] = (
-                enc_names[last_name_offset:name_offset].decode('utf-8')
-            )
+            names[i - 1] = enc_names[last_name_offset:name_offset].decode("utf-8")
         last_name_offset = name_offset
 
         #
         if last_data_offset is not None:
-            values[i - 1] = decode(last_dtype,
-                                   data[last_data_offset:data_offset])
+            values[i - 1] = decode(last_dtype, data[last_data_offset:data_offset])
         last_data_offset = data_offset
         last_dtype = dtype
 
-    names[column_count - 1] = enc_names[last_name_offset:].decode('utf-8')
+    names[column_count - 1] = enc_names[last_name_offset:].decode("utf-8")
     values[column_count - 1] = decode(last_dtype, data[last_data_offset:])
 
     # join data and names
-    return {
-        names[i]: values[i]
-        for i in range(column_count)
-    }
+    return {names[i]: values[i] for i in range(column_count)}
 
 
 def decode_data_size(flags):
     t = flags & 0x03
     if t == 0:
-        return 'H', 4, 0xFFFF
+        return "H", 4, 0xFFFF
     elif t == 1:
-        return 'L', 5, 0xFFFFFF
+        return "L", 5, 0xFFFFFF
     elif t == 2:
-        return 'L', 6, 0xFFFFFFFF
+        return "L", 6, 0xFFFFFFFF
     else:
         raise ValueError("Unknown dynamic columns format")
 
@@ -351,25 +325,25 @@ def decode_int(encvalue):
     if value & 1:
         return -(value >> 1) - 1
     else:
-        return (value >> 1)
+        return value >> 1
 
 
 def decode_uint(encvalue):
-    value, = struct_unpack('Q', encvalue)
+    value, = struct_unpack("Q", encvalue)
     return value
 
 
 def decode_double(encvalue):
-    value, = struct_unpack('d', encvalue)
+    value, = struct_unpack("d", encvalue)
     return value
 
 
 def decode_string(encvalue):
-    if not encvalue.startswith((b'\x21', b'\x2D')):
+    if not encvalue.startswith((b"\x21", b"\x2D")):
         raise DynColNotSupported(
             "Can only decode strings with MySQL charsets utf8 or utf8mb4"
         )
-    return encvalue[1:].decode('utf-8')
+    return encvalue[1:].decode("utf-8")
 
 
 def decode_decimal(encvalue):
@@ -394,30 +368,26 @@ def decode_datetime(encvalue):
 
 
 def decode_date(encvalue):
-    val, = struct_unpack('I', encvalue + b'\x00')
-    return date(
-        day=val & 0x1F,
-        month=(val >> 5) & 0xF,
-        year=(val >> 9)
-    )
+    val, = struct_unpack("I", encvalue + b"\x00")
+    return date(day=val & 0x1F, month=(val >> 5) & 0xF, year=(val >> 9))
 
 
 def decode_time(encvalue):
     if len(encvalue) == 6:
-        val, = struct_unpack('Q', encvalue + b'\x00\x00')
+        val, = struct_unpack("Q", encvalue + b"\x00\x00")
         return time(
             microsecond=val & 0xFFFFF,
             second=(val >> 20) & 0x3F,
             minute=(val >> 26) & 0x3F,
-            hour=(val >> 32)
+            hour=(val >> 32),
         )
     else:  # must be 3
-        val, = struct_unpack('I', encvalue + b'\x00')
+        val, = struct_unpack("I", encvalue + b"\x00")
         return time(
             microsecond=0,
             second=(val) & 0x3F,
             minute=(val >> 6) & 0x3F,
-            hour=(val >> 12)
+            hour=(val >> 12),
         )
 
 

--- a/requirements/py35.txt
+++ b/requirements/py35.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via hypothesis, pytest
+    # via flake8-bugbear, hypothesis, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -32,6 +32,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py36.txt
+++ b/requirements/py36.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via hypothesis, pytest
+    # via flake8-bugbear, hypothesis, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -32,6 +32,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py37.txt
+++ b/requirements/py37.txt
@@ -4,6 +4,10 @@
 #
 #    ./compile.sh
 #
+appdirs==1.4.3 \
+    --hash=sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
+    --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e \
+    # via black
 atomicwrites==1.3.0 \
     --hash=sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4 \
     --hash=sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6 \
@@ -11,7 +15,10 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via hypothesis, pytest
+    # via black, flake8-bugbear, hypothesis, pytest
+black==19.3b0 ; python_version == "3.7.*" \
+    --hash=sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf \
+    --hash=sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -24,6 +31,10 @@ chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     # via requests
+click==7.0 \
+    --hash=sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13 \
+    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7 \
+    # via black
 docutils==0.14 \
     --hash=sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6 \
     --hash=sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274 \
@@ -32,6 +43,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8
@@ -117,6 +131,10 @@ six==1.12.0 \
     --hash=sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c \
     --hash=sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73 \
     # via bleach, packaging, pytest, readme-renderer
+toml==0.10.0 \
+    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
+    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
+    # via black
 tqdm==4.32.1 \
     --hash=sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab \
     --hash=sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b \

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,5 +1,7 @@
+black ; python_version == '3.7.*'
 docutils
 flake8
+flake8-bugbear
 hypothesis
 isort
 multilint

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,16 @@
 [flake8]
-max-line-length = 120
+max-line-length = 80
+select = C,E,F,W,B,B950
+ignore = E203,E501,W503
 
 [isort]
+include_trailing_comma = True
+force_grid_wrap = 0
 known_first_party = mariadb_dyncol
-line_length = 120
-multi_line_output = 5
+line_length = 88
+multi_line_output = 3
 not_skip = __init__.py
+use_parentheses = True
 
 [metadata]
 license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -5,45 +5,45 @@ from setuptools import find_packages, setup
 
 
 def get_version(filename):
-    with open(filename, 'r') as fp:
+    with open(filename, "r") as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
 
-version = get_version(os.path.join('mariadb_dyncol', '__init__.py'))
+version = get_version(os.path.join("mariadb_dyncol", "__init__.py"))
 
-with open('README.rst', 'r') as readme_file:
+with open("README.rst", "r") as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst', 'r') as history_file:
-    history = history_file.read().replace('.. :changelog:', '')
+with open("HISTORY.rst", "r") as history_file:
+    history = history_file.read().replace(".. :changelog:", "")
 
 
 setup(
-    name='mariadb-dyncol',
+    name="mariadb-dyncol",
     version=version,
     description="Pack/unpack Python dicts into/out of MariaDB's Dynamic "
-                "Columns format.",
-    long_description=readme + '\n\n' + history,
+    "Columns format.",
+    long_description=readme + "\n\n" + history,
     author="Adam Johnson",
-    author_email='me@adamj.eu',
-    url='https://github.com/adamchainz/mariadb-dyncol',
-    packages=find_packages(exclude=['tests', 'tests.*']),
+    author_email="me@adamj.eu",
+    url="https://github.com/adamchainz/mariadb-dyncol",
+    packages=find_packages(exclude=["tests", "tests.*"]),
     include_package_data=True,
-    python_requires='>=3.5',
+    python_requires=">=3.5",
     license="BSD",
     zip_safe=False,
-    keywords='MariaDB',
+    keywords="MariaDB",
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Natural Language :: English',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Natural Language :: English",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,6 @@ import os
 
 from hypothesis import settings
 
-local_settings = settings(
-    max_examples=int(os.getenv('HYPOTHESIS_MAX_EXAMPLES', 100)),
-)
+local_settings = settings(max_examples=int(os.getenv("HYPOTHESIS_MAX_EXAMPLES", 100)))
 settings.register_profile("fuzztests", local_settings)
 settings.load_profile("fuzztests")

--- a/tests/test_fuzzily_with_hypothesis.py
+++ b/tests/test_fuzzily_with_hypothesis.py
@@ -1,28 +1,29 @@
 from math import isinf, isnan
 
 from hypothesis import assume, given
-from hypothesis.strategies import dates, datetimes, dictionaries, floats, integers, recursive, text, times
+from hypothesis.strategies import (
+    dates,
+    datetimes,
+    dictionaries,
+    floats,
+    integers,
+    recursive,
+    text,
+    times,
+)
 
 from mariadb_dyncol import DynColValueError, pack, unpack
 from mariadb_dyncol.base import MAX_NAME_LENGTH, MAX_TOTAL_NAME_LENGTH  # priv.
 
 from .base import check_against_db
 
-valid_keys = text(
-    min_size=1,
-    max_size=MAX_NAME_LENGTH
-).filter(
-    lambda key: len(key.encode('utf-8')) <= MAX_NAME_LENGTH
+valid_keys = text(min_size=1, max_size=MAX_NAME_LENGTH).filter(
+    lambda key: len(key.encode("utf-8")) <= MAX_NAME_LENGTH
 )
-valid_ints = integers(
-    min_value=-(2 ** 31 - 1),
-    max_value=(2 ** 64 - 1)
-).filter(
+valid_ints = integers(min_value=-(2 ** 31 - 1), max_value=(2 ** 64 - 1)).filter(
     lambda i: abs(i) <= (2 ** 31 - 1) or 0 <= i <= 2 ** 64 - 1
 )
-valid_floats = floats().filter(
-    lambda f: not isnan(f) and not isinf(f)
-)
+valid_floats = floats().filter(lambda f: not isnan(f) and not isinf(f))
 valid_datetimes = datetimes()
 valid_dates = dates()
 valid_times = times()
@@ -31,9 +32,8 @@ valid_times = times()
 def valid_dictionaries(keys, values):
     return dictionaries(keys, values).filter(
         lambda data: (
-            sum(len(key.encode('utf-8')) for key in data) <=
-            MAX_TOTAL_NAME_LENGTH
-        ),
+            sum(len(key.encode("utf-8")) for key in data) <= MAX_TOTAL_NAME_LENGTH
+        )
     )
 
 
@@ -77,9 +77,8 @@ def test_times(data):
 
 
 recursive_values = recursive(
-    (valid_ints | valid_floats | text() | valid_datetimes | valid_dates |
-     valid_times),
-    lambda children: valid_dictionaries(valid_keys, children)
+    (valid_ints | valid_floats | text() | valid_datetimes | valid_dates | valid_times),
+    lambda children: valid_dictionaries(valid_keys, children),
 )
 
 


### PR DESCRIPTION
* Add black and flake8-bugbear - automatically picked up by multilint
* Add pyproject.toml black configuration to target Python 3.5
* Reconfigure isort and flake8
* Drop flake8-commas and rely on Black's trailing comma insertion only
* Run black on the code
* Add README badge