### PR TITLE
Drop not_skip = __init__.py from isort config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,6 @@ force_grid_wrap = 0
 known_first_party = mariadb_dyncol
 line_length = 88
 multi_line_output = 3
-not_skip = __init__.py
 use_parentheses = True
 
 [metadata]


### PR DESCRIPTION
It was removed from the default ignore list in [Version 4.3.5](https://github.com/timothycrosley/isort/blob/develop/CHANGELOG.md#435---february-24-2019---last-python-27-maintenance-release).