### PR TITLE
Reword supported versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Use **pip**:
 
     pip install mariadb-dyncol
 
-Python 3.5-3.8 supported.
+Python 3.5 to 3.8 supported.
 
 Features
 ========


### PR DESCRIPTION
As per https://github.com/adamchainz/django-cors-headers/pull/468 , using a dash has confused some users.