### PR TITLE
Switch 'pip install' for 'python -m pip install'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ matrix:
 
 before_script: .travis/before_script.sh
 
-install: pip install tox-travis
+install: python -m pip install tox-travis
 
 script: HYPOTHESIS_MAX_EXAMPLES=1000 tox

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Use **pip**:
 
 .. code-block:: sh
 
-    pip install mariadb-dyncol
+    python -m pip install mariadb-dyncol
 
 Python 3.5 to 3.8 supported.
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
 
 [testenv]
 passenv = HYPOTHESIS_MAX_EXAMPLES
-install_command = pip install --no-deps {opts} {packages}
+install_command = python -m pip install --no-deps {opts} {packages}
 commands = pytest {posargs}
 
 [testenv:py35]


### PR DESCRIPTION
As per [Brett Cannon's article](https://snarky.ca/why-you-should-use-python-m-pip/).