### PR TITLE
Ensure wheel installed on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,8 +50,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools
-        python -m pip install --upgrade setuptools tox tox-py
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade tox tox-py
 
     - name: Run tox targets for ${{ matrix.python-version }}
       run: tox --py current


### PR DESCRIPTION
This means for non-wheel packages, pip can compile a wheel that will get cached and reused between runs.