### PR TITLE
Move from isort to reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,16 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==22.10.0
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v3.9.0
   hooks:
-  - id: isort
+  - id: reorder-python-imports
+    args:
+    - --py37-plus
+    - --application-directories
+    - .:example:src
+    - --add-import
+    - 'from __future__ import annotations'
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:

--- a/benchmark.py
+++ b/benchmark.py
@@ -5,9 +5,14 @@ import io
 import sys
 import time
 from contextlib import contextmanager
-from typing import IO, Any, Callable, ContextManager, Generator
+from typing import Any
+from typing import Callable
+from typing import ContextManager
+from typing import Generator
+from typing import IO
 
-from tests import base, test_mariadb_dyncol
+from tests import base
+from tests import test_mariadb_dyncol
 
 
 def main() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 target-version = ['py37']
 
-[tool.isort]
-profile = "black"
-add_imports = "from __future__ import annotations"
-
 [tool.mypy]
 mypy_path = "src/"
 show_error_codes = true

--- a/src/mariadb_dyncol/__init__.py
+++ b/src/mariadb_dyncol/__init__.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from .base import (
-    DynColLimitError,
-    DynColNotSupported,
-    DynColTypeError,
-    DynColValueError,
-    pack,
-    unpack,
-)
+from .base import DynColLimitError
+from .base import DynColNotSupported
+from .base import DynColTypeError
+from .base import DynColValueError
+from .base import pack
+from .base import unpack
 
 __all__ = (
     "DynColLimitError",

--- a/src/mariadb_dyncol/base.py
+++ b/src/mariadb_dyncol/base.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
-from datetime import date, datetime, time
+from datetime import date
+from datetime import datetime
+from datetime import time
 from decimal import Decimal
-from math import isinf, isnan
+from math import isinf
+from math import isnan
 from struct import pack as struct_pack
 from struct import unpack as struct_unpack
 from struct import unpack_from as struct_unpack_from
-from typing import TYPE_CHECKING, Any, Callable
+from typing import Any
+from typing import Callable
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import NoReturn

--- a/tests/base.py
+++ b/tests/base.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import binascii
 import os
-from datetime import date, datetime, time
+from datetime import date
+from datetime import datetime
+from datetime import time
 from typing import Any
 
 import pymysql
 
-from mariadb_dyncol import pack, unpack
+from mariadb_dyncol import pack
+from mariadb_dyncol import unpack
 
 hexs = binascii.hexlify
 unhexs = binascii.unhexlify

--- a/tests/test_fuzzily_with_hypothesis.py
+++ b/tests/test_fuzzily_with_hypothesis.py
@@ -1,24 +1,26 @@
 from __future__ import annotations
 
-from math import isinf, isnan
+from math import isinf
+from math import isnan
 from typing import Any
 
-from hypothesis import assume, given
-from hypothesis.strategies import (
-    dates,
-    datetimes,
-    dictionaries,
-    floats,
-    integers,
-    recursive,
-    text,
-    times,
-)
-
-from mariadb_dyncol import DynColValueError, pack, unpack
-from mariadb_dyncol.base import MAX_NAME_LENGTH, MAX_TOTAL_NAME_LENGTH  # priv.
+from hypothesis import assume
+from hypothesis import given
+from hypothesis.strategies import dates
+from hypothesis.strategies import datetimes
+from hypothesis.strategies import dictionaries
+from hypothesis.strategies import floats
+from hypothesis.strategies import integers
+from hypothesis.strategies import recursive
+from hypothesis.strategies import text
+from hypothesis.strategies import times
 
 from .base import check_against_db
+from mariadb_dyncol import DynColValueError
+from mariadb_dyncol import pack
+from mariadb_dyncol import unpack
+from mariadb_dyncol.base import MAX_NAME_LENGTH
+from mariadb_dyncol.base import MAX_TOTAL_NAME_LENGTH
 
 valid_keys = text(min_size=1, max_size=MAX_NAME_LENGTH).filter(
     lambda key: len(key.encode("utf-8")) <= MAX_NAME_LENGTH

--- a/tests/test_mariadb_dyncol.py
+++ b/tests/test_mariadb_dyncol.py
@@ -1,21 +1,22 @@
 from __future__ import annotations
 
-from datetime import date, datetime, time
+from datetime import date
+from datetime import datetime
+from datetime import time
 from decimal import Decimal
 
 import pytest
 
-from mariadb_dyncol import (
-    DynColLimitError,
-    DynColNotSupported,
-    DynColTypeError,
-    DynColValueError,
-    pack,
-    unpack,
-)
+from .base import check
+from .base import hexs
+from .base import unhexs
+from mariadb_dyncol import DynColLimitError
+from mariadb_dyncol import DynColNotSupported
+from mariadb_dyncol import DynColTypeError
+from mariadb_dyncol import DynColValueError
+from mariadb_dyncol import pack
+from mariadb_dyncol import unpack
 from mariadb_dyncol.base import MAX_NAME_LENGTH  # private but useful in tests
-
-from .base import check, hexs, unhexs
 
 
 def test_empty():


### PR DESCRIPTION
It’s [way faster](https://twitter.com/codewithanthony/status/1553034384206438401) and its one-import-per-line style prevents merge conflicts.
